### PR TITLE
VS-52: Support multiple diagnostics in a single test case

### DIFF
--- a/tests/MongoDB.Analyzer.Tests.Common.TestCases/Builders/BuildersBasic.cs
+++ b/tests/MongoDB.Analyzer.Tests.Common.TestCases/Builders/BuildersBasic.cs
@@ -28,15 +28,11 @@ namespace MongoDB.Analyzer.Tests.Common.TestCases.Builders
             _ = Builders<User>.Filter.Exists(u => u.Address, false);
         }
 
-        [BuildersMQL("{ \"Age\" : 1 }")]
-        public void Sort_single_expression_ascending()
+        [BuildersMQL("{ \"Age\" : 1 }", 34, 34)]
+        [BuildersMQL("{ \"Age\" : -1 }", 35, 35)]
+        public void Sort_single_expression()
         {
             _ = Builders<User>.Sort.Ascending(u => u.Age);
-        }
-
-        [BuildersMQL("{ \"Age\" : -1 }")]
-        public void Sort_single_expression_descending()
-        {
             _ = Builders<User>.Sort.Descending(u => u.Age);
         }
 

--- a/tests/MongoDB.Analyzer.Tests.Common/DiagnosticTestCaseAttribute.cs
+++ b/tests/MongoDB.Analyzer.Tests.Common/DiagnosticTestCaseAttribute.cs
@@ -22,6 +22,7 @@ namespace MongoDB.Analyzer.Tests.Common
         public string RuleId { get; }
         public string Message { get; }
         public string Version { get; }
+        public Location Location { get; }
         public DriverTargetFramework TargetFramework { get; }
         public LinqVersion LinqProvider { get; }
 
@@ -30,13 +31,15 @@ namespace MongoDB.Analyzer.Tests.Common
             string message,
             string version = null,
             LinqVersion linqProvider = LinqVersion.V2,
-            DriverTargetFramework targetFramework = DriverTargetFramework.All)
+            DriverTargetFramework targetFramework = DriverTargetFramework.All,
+            Location location = null)
         {
             RuleId = ruleId;
             Message = message;
             Version = version;
-            TargetFramework = targetFramework;
             LinqProvider = linqProvider;
+            TargetFramework = targetFramework;
+            Location = location;
         }
     }
 
@@ -102,8 +105,8 @@ namespace MongoDB.Analyzer.Tests.Common
 
     public sealed class BuildersMQLAttribute : DiagnosticRuleTestCaseAttribute
     {
-        public BuildersMQLAttribute(string message) :
-            base(DiagnosticRulesConstants.Builders2MQL, message)
+        public BuildersMQLAttribute(string message, int startLine = -1, int endLine = -1) :
+            base(DiagnosticRulesConstants.Builders2MQL, message, location: new Location(startLine, endLine))
         {
         }
     }

--- a/tests/MongoDB.Analyzer.Tests.Common/Location.cs
+++ b/tests/MongoDB.Analyzer.Tests.Common/Location.cs
@@ -13,22 +13,19 @@
 // limitations under the License.
 
 using System;
-using MongoDB.Analyzer.Tests.Common;
 
-namespace MongoDB.Analyzer.Tests.Infrastructure;
-
-[Serializable]
-public record DiagnosticRule(
-    string RuleId,
-    string Message,
-    Location Location);
-
-[Serializable]
-public record DiagnosticTestCase(
-    string FileName,
-    string MethodName,
-    string Version,
-    LinqVersion LinqVersion,
-    DiagnosticRule[] DiagnosticRules)
+namespace MongoDB.Analyzer.Tests.Common
 {
+    [Serializable]
+    public sealed class Location
+    {
+        public int StartLine { get; }
+        public int EndLine { get; }
+
+        public Location(int startLine, int endLine)
+        {
+            StartLine = startLine;
+            EndLine = endLine;
+        }
+    }
 }

--- a/tests/MongoDB.Analyzer.Tests.Common/MongoDB.Analyzer.Tests.Common.projitems
+++ b/tests/MongoDB.Analyzer.Tests.Common/MongoDB.Analyzer.Tests.Common.projitems
@@ -32,5 +32,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)MongoDBProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestCasesBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DataModel\User.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Location.cs" />
   </ItemGroup>
 </Project>

--- a/tests/MongoDB.Analyzer.Tests/Infrastructure/CodeBasedTestCasesSourceAttribute.cs
+++ b/tests/MongoDB.Analyzer.Tests/Infrastructure/CodeBasedTestCasesSourceAttribute.cs
@@ -65,7 +65,7 @@ public sealed class CodeBasedTestCasesSourceAttribute : Attribute, ITestDataSour
             from attribute in testCasesAttributes
             where EnvironmentUtilities.IsDriverTargetFrameworkSupported((Core.DriverTargetFramework)(int)attribute.TargetFramework)
             from version in DriverVersionHelper.FilterVersionForRange(attribute.Version)
-            group new DiagnosticRule(attribute.RuleId, $"{attribute.Message}_v{version.ToString("V", new VersionFormatter())}")
+            group new DiagnosticRule(attribute.RuleId, $"{attribute.Message}_v{version.ToString("V", new VersionFormatter())}", attribute.Location)
                 by new { version, attribute.LinqProvider } into g
             select new DiagnosticTestCase(fileName, memberInfo.Name, g.Key.version.ToString(), g.Key.LinqProvider, g.ToArray());
 

--- a/tests/MongoDB.Analyzer.Tests/Infrastructure/DiagnosticsTestCasesRunner.cs
+++ b/tests/MongoDB.Analyzer.Tests/Infrastructure/DiagnosticsTestCasesRunner.cs
@@ -44,5 +44,15 @@ public abstract class DiagnosticsTestCasesRunner
     {
         Assert.AreEqual(diagnosticRule.RuleId, diagnostic.Id);
         Assert.AreEqual(diagnosticRule.Message, diagnostic.GetMessage());
+
+        var location = diagnosticRule.Location;
+        if (location?.StartLine >= 0)
+        {
+            Assert.AreEqual(location.StartLine, diagnostic.Location.GetLineSpan().StartLinePosition.Line);
+        }
+        if (location?.EndLine >= 0)
+        {
+            Assert.AreEqual(location.EndLine, diagnostic.Location.GetLineSpan().EndLinePosition.Line);
+        }
     }
 }

--- a/tests/MongoDB.Analyzer.Tests/Infrastructure/PathUtilities.cs
+++ b/tests/MongoDB.Analyzer.Tests/Infrastructure/PathUtilities.cs
@@ -45,7 +45,6 @@ internal static class PathUtilities
         }
     }
 
-
     private static string GetFullPathRelativeToParent(string partialPath) =>
         Path.GetFullPath(Path.Combine(s_projectParentFolderPrefix, partialPath));
 }

--- a/tests/MongoDB.Analyzer.Tests/Infrastructure/PathUtilities.cs
+++ b/tests/MongoDB.Analyzer.Tests/Infrastructure/PathUtilities.cs
@@ -20,17 +20,17 @@ internal static class PathUtilities
 {
     private static readonly string s_testCasesBaseNamespace = "MongoDB.Analyzer.Tests.Common.TestCases";
     private static readonly string s_testCasesBaseFolder = s_testCasesBaseNamespace;
-    private static readonly string s_projectParentFolderPrefix = @"..\..\..\..\";
+    private static readonly string s_projectParentFolderPrefix = Path.Combine("..", "..", "..", "..");
     private static readonly string s_testCasesPath = GetFullPathRelativeToParent(s_testCasesBaseFolder);
 
-    public static string TestDataModelAssemblyPath { get; } = GetFullPathRelativeToParent(@"MongoDB.Analyzer.Tests.Common.ClassLibrary\bin\Debug\netstandard2.0\MongoDB.Analyzer.Tests.Common.ClassLibrary");
+    public static string TestDataModelAssemblyPath { get; } = GetFullPathRelativeToParent(@"MongoDB.Analyzer.Tests.Common.ClassLibrary/bin/Debug/netstandard2.0/MongoDB.Analyzer.Tests.Common.ClassLibrary");
 
     public static string GetTestCaseFileFullPathFromName(string testCaseFullyQualifiedName)
     {
         var pathNameFromTypeName = testCaseFullyQualifiedName
             .Replace(s_testCasesBaseNamespace, string.Empty)
             .Trim('.')
-            .Replace('.', '\\');
+            .Replace('.', Path.DirectorySeparatorChar);
 
         var result = Path.Combine(s_testCasesPath, pathNameFromTypeName + ".cs");
         return result;
@@ -47,5 +47,5 @@ internal static class PathUtilities
 
 
     private static string GetFullPathRelativeToParent(string partialPath) =>
-        Path.GetFullPath(s_projectParentFolderPrefix + partialPath);
+        Path.GetFullPath(Path.Combine(s_projectParentFolderPrefix, partialPath));
 }

--- a/tests/MongoDB.Analyzer.Tests/Infrastructure/PathUtilities.cs
+++ b/tests/MongoDB.Analyzer.Tests/Infrastructure/PathUtilities.cs
@@ -23,7 +23,7 @@ internal static class PathUtilities
     private static readonly string s_projectParentFolderPrefix = Path.Combine("..", "..", "..", "..");
     private static readonly string s_testCasesPath = GetFullPathRelativeToParent(s_testCasesBaseFolder);
 
-    public static string TestDataModelAssemblyPath { get; } = GetFullPathRelativeToParent(@"MongoDB.Analyzer.Tests.Common.ClassLibrary/bin/Debug/netstandard2.0/MongoDB.Analyzer.Tests.Common.ClassLibrary");
+    public static string TestDataModelAssemblyPath { get; } = GetFullPathRelativeToParent("MongoDB.Analyzer.Tests.Common.ClassLibrary", "bin", "Debug", "netstandard2.0", "MongoDB.Analyzer.Tests.Common.ClassLibrary");
 
     public static string GetTestCaseFileFullPathFromName(string testCaseFullyQualifiedName)
     {
@@ -45,6 +45,6 @@ internal static class PathUtilities
         }
     }
 
-    private static string GetFullPathRelativeToParent(string partialPath) =>
-        Path.GetFullPath(Path.Combine(s_projectParentFolderPrefix, partialPath));
+    private static string GetFullPathRelativeToParent(params string[] pathComponents) =>
+        Path.GetFullPath(Path.Combine(s_projectParentFolderPrefix, pathComponents.Length == 1 ? pathComponents[0] : Path.Combine(pathComponents)));
 }


### PR DESCRIPTION
Updated the testing framework to support multiple diagnostics in a single test case. Updates were made to enable tests to pass in integer parameter to BuildersMQLAttribute indicating the start and end line number of the expected location of each Diagnostic. Upon passing in integer parameters, the start/end line was represented internally using a Location record and the Location was eventually validated in DiagnosticsTestCasesRunner.cs