### PR TITLE
VS-51: Builders reassigned expressions are not analyzed

### DIFF
--- a/src/MongoDB.Analyzer/Core/Builders/BuilderExpressionProcessor.cs
+++ b/src/MongoDB.Analyzer/Core/Builders/BuilderExpressionProcessor.cs
@@ -87,7 +87,7 @@ internal static class BuilderExpressionProcessor
                     typesProcessor.ProcessTypeSymbol(typeArgument);
                 }
 
-                var (newBuildersExpression, constantsMapper) = RewriteBuildersExpression(node, typesProcessor, semanticModel);
+                var (newBuildersExpression, constantsMapper) = RewriteBuildersExpression(builderExpressionNode, typesProcessor, semanticModel);
 
                 if (newBuildersExpression != null)
                 {

--- a/tests/MongoDB.Analyzer.Tests.Common.TestCases/Builders/BuildersBasic.cs
+++ b/tests/MongoDB.Analyzer.Tests.Common.TestCases/Builders/BuildersBasic.cs
@@ -268,5 +268,57 @@ namespace MongoDB.Analyzer.Tests.Common.TestCases.Builders
                 return 1;
             });
         }
+
+        [BuildersMQL("{ \"Address\" : { \"$exists\" : false } }", 275)]
+        [BuildersMQL("{ \"Address\" : { \"$exists\" : true } }", 276)]
+        public void Single_expression_variable_reassignment()
+        {
+            var x = Builders<User>.Filter.Exists(u => u.Address, false);
+            x = Builders<User>.Filter.Exists(u => u.Address, true);
+        }
+
+        [BuildersMQL("{ \"Age\" : 25 }", 291)]
+        [BuildersMQL("{ \"Age\" : { \"$lt\" : 65 } }", 292)]
+        [BuildersMQL("{ \"Age\" : { \"$gt\" : 11 } }", 294)]
+        [BuildersMQL("{ \"Age\" : { \"$lt\" : 25 } }", 295)]
+        [BuildersMQL("{ \"Age\" : 100 }", 297)]
+        [BuildersMQL("{ \"Age\" : 11 }", 298)]
+        [BuildersMQL("{ \"Age\" : 1 }", 300)]
+        [BuildersMQL("{ \"Age\" : { \"$gt\" : 1 } }", 301)]
+        [BuildersMQL("{ \"Age\" : 200 }", 303)]
+        [BuildersMQL("{ \"Age\" : -1 }", 304)]
+        public void Multiple_expression_variables_reassignment()
+        {
+            var x = Builders<User>.Filter.Eq(u => u.Age, 25);
+            var y = Builders<User>.Filter.Lt(u => u.Age, 65);
+
+            x = Builders<User>.Filter.Gt(u => u.Age, 11);
+            var z = Builders<User>.Filter.Lt(u => u.Age, 25);
+
+            y = Builders<User>.Filter.Eq(u => u.Age, 100);
+            x = Builders<User>.Filter.Eq(u => u.Age, 11);
+
+            var w = Builders<User>.Sort.Ascending(u => u.Age);
+            z = Builders<User>.Filter.Gt(u => u.Age, 1);
+
+            y = Builders<User>.Filter.Eq(u => u.Age, 200);
+            w = Builders<User>.Sort.Descending(u => u.Age);
+        }
+
+        [BuildersMQL("{ \"Address\" : \"1\" }", 315)]
+        [BuildersMQL("{ \"Address\" : \"2\" }", 316)]
+        [BuildersMQL("{ \"Address\" : \"3\" }", 317)]
+        [BuildersMQL("{ \"Address\" : \"4\" }", 317)]
+        [BuildersMQL("{ \"Age\" : { \"$lt\" : 15, \"$gt\" : 65 } }", 319)]
+        [BuildersMQL("{ \"Age\" : { \"$lt\" : 17, \"$gt\" : 18 } }", 320)]
+        public void Multiple_expression_variables_declaration_and_reassignment()
+        {
+            var x = Builders<User>.Filter.Eq(u => u.Address, "1");
+            var y = Builders<User>.Filter.Eq(u => u.Address, "2");
+            FilterDefinition<User> z = Builders<User>.Filter.Eq(u => u.Address, "3"), w = (Builders<User>.Filter.Eq(u => u.Address, "4"));
+
+            x = y = Builders<User>.Filter.Lt(u => u.Age, 15) & Builders<User>.Filter.Gt(u => u.Age, 65);
+            x = z = w = y = x = z = w = y = Builders<User>.Filter.Lt(u => u.Age, 17) & Builders<User>.Filter.Gt(u => u.Age, 18);
+        }
     }
 }

--- a/tests/MongoDB.Analyzer.Tests.Common.TestCases/Linq/LinqBasic.cs
+++ b/tests/MongoDB.Analyzer.Tests.Common.TestCases/Linq/LinqBasic.cs
@@ -167,5 +167,57 @@ namespace MongoDB.Analyzer.Tests.Common.TestCases.Linq
                 return 1;
             });
         }
+
+        [MQL("aggregate([{ \"$match\" : { \"Name\" : \"Bob\", \"Age\" : { \"$gt\" : 16, \"$lte\" : 21 } } }])", startLine: 174)]
+        [MQL("aggregate([{ \"$match\" : { \"Name\" : \"John\", \"Age\" : { \"$gt\" : 45, \"$lte\" : 50 } } }])", startLine: 175)]
+        public void Single_expression_variable_reassignment()
+        {
+            var x = GetMongoCollection().AsQueryable().Where(u => u.Name == "Bob" && u.Age > 16 && u.Age <= 21);
+            x = GetMongoCollection().AsQueryable().Where(u => u.Name == "John" && u.Age > 45 && u.Age <= 50);
+        }
+
+        [MQL("aggregate([{ \"$match\" : { \"Age\" : 45 } }])", startLine: 190)]
+        [MQL("aggregate([{ \"$match\" : { \"Name\" : \"John\" } }])", startLine: 191)]
+        [MQL("aggregate([{ \"$match\" : { \"Name\" : \"Bob\", \"Age\" : { \"$gt\" : 16, \"$lte\" : 21 } } }])", startLine: 193)]
+        [MQL("aggregate([{ \"$match\" : { \"Name\" : \"James\", \"Age\" : { \"$gt\" : 25, \"$lte\" : 99 } } }])", startLine: 194)]
+        [MQL("aggregate([{ \"$match\" : { \"Name\" : \"Steve\" } }])", startLine: 196)]
+        [MQL("aggregate([{ \"$match\" : { \"Height\" : 100 } }])", startLine: 197)]
+        [MQL("aggregate([{ \"$match\" : { \"Age\" : 22 } }])", startLine: 199)]
+        [MQL("aggregate([{ \"$match\" : { \"LastName\" : \"LastName\" } }])", startLine: 200)]
+        [MQL("aggregate([{ \"$match\" : { \"Address\" : \"Address\" } }])", startLine: 202)]
+        [MQL("aggregate([{ \"$match\" : { \"Age\" : { \"$lte\" : 122 } } }])", startLine: 203)]
+        public void Multiple_expression_variables_reassignment()
+        {
+            var x = GetMongoCollection().AsQueryable().Where(u => u.Age == 45);
+            var y = GetMongoCollection().AsQueryable().Where(u => u.Name == "John");
+
+            x = GetMongoCollection().AsQueryable().Where(u => u.Name == "Bob" && u.Age > 16 && u.Age <= 21);
+            var z = GetMongoCollection().AsQueryable().Where(u => u.Name == "James" && u.Age > 25 && u.Age <= 99);
+
+            y = GetMongoCollection().AsQueryable().Where(u => u.Name == "Steve");
+            x = GetMongoCollection().AsQueryable().Where(u => u.Height == 100);
+
+            var w = GetMongoCollection().AsQueryable().Where(u => u.Age == 22);
+            z = GetMongoCollection().AsQueryable().Where(u => u.LastName == "LastName");
+
+            y = GetMongoCollection().AsQueryable().Where(u => u.Address == "Address");
+            w = GetMongoCollection().AsQueryable().Where(u => u.Age <= 122);
+        }
+
+        [MQL("aggregate([{ \"$match\" : { \"Name\" : \"Bob\", \"Age\" : { \"$gt\" : 16, \"$lte\" : 21 } } }])", startLine: 214)]
+        [MQL("aggregate([{ \"$match\" : { \"Name\" : \"John\", \"Age\" : { \"$gt\" : 22, \"$lte\" : 25 } } }])", startLine: 215)]
+        [MQL("aggregate([{ \"$match\" : { \"Name\" : \"Steve\", \"Age\" : { \"$gt\" : 27, \"$lte\" : 31 } } }])", startLine: 216)]
+        [MQL("aggregate([{ \"$match\" : { \"LastName\" : \"LastName\" } }])", startLine: 216)]
+        [MQL("aggregate([{ \"$match\" : { \"Address\" : \"Address\" } }])", startLine: 218)]
+        [MQL("aggregate([{ \"$match\" : { \"Height\" : 180 } }])", startLine: 219)]
+        public void Multiple_expression_variables_declaration_and_reassignment()
+        {
+            var x = GetMongoCollection().AsQueryable().Where(u => u.Name == "Bob" && u.Age > 16 && u.Age <= 21);
+            var y = GetMongoCollection().AsQueryable().Where(u => u.Name == "John" && u.Age > 22 && u.Age <= 25);
+            IMongoQueryable<User> z = GetMongoCollection().AsQueryable().Where(u => u.Name == "Steve" && u.Age > 27 && u.Age <= 31), w = (GetMongoCollection().AsQueryable().Where(u => u.LastName == "LastName"));
+
+            x = y = GetMongoCollection().AsQueryable().Where(u => u.Address == "Address");
+            x = z = w = y = x = z = w = y = GetMongoCollection().AsQueryable().Where(u => u.Height == 180);
+        }
     }
 }

--- a/tests/MongoDB.Analyzer.Tests.Common/DiagnosticTestCaseAttribute.cs
+++ b/tests/MongoDB.Analyzer.Tests.Common/DiagnosticTestCaseAttribute.cs
@@ -55,7 +55,9 @@ namespace MongoDB.Analyzer.Tests.Common
             string message,
             string version = null,
             LinqVersion linqProvider = LinqVersion.V2,
-            DriverTargetFramework targetFramework = DriverTargetFramework.All) :
+            DriverTargetFramework targetFramework = DriverTargetFramework.All,
+            int startLine = -1,
+            int endLine = -1) :
             base(DiagnosticRulesConstants.MongoLinq2MQL, message, version, linqProvider, targetFramework)
         {
         }


### PR DESCRIPTION
Originally, in the Analyzer, Assignments were not analyzed. For example, 


var filter = Builders<Movie>.Filter.Eq(m => m.Genre, genre);
--
filter = Builders<Movie>.Filter.Gte(m => m.Score, 12);

The second assignment would not be analyzed. This code branch fixes this bug and incorporates a few representative test cases which all pass. Furthermore, the code fix does NOT impair any of the existing test cases. In all, 100% of the test cases(both existing and newly written) pass. 