### PR TITLE
VS-95: Made TypesProcessor a shared instance between all Linq and Builders Operations

### DIFF
--- a/src/MongoDB.Analyzer/Core/Builders/AnalysisCodeGenerator.cs
+++ b/src/MongoDB.Analyzer/Core/Builders/AnalysisCodeGenerator.cs
@@ -34,7 +34,7 @@ internal static class AnalysisCodeGenerator
         s_parseOptions = mqlGeneratorSyntaxTree.Options;
     }
 
-    public static CompilationResult Compile(MongoAnalyzerContext context, ExpressionsAnalysis buildersExpressionAnalysis)
+    public static CompilationResult Compile(MongoAnalysisContext context, ExpressionsAnalysis buildersExpressionAnalysis)
     {
         var semanticModel = context.SemanticModelAnalysisContext.SemanticModel;
         var referencesContainer = ReferencesProvider.GetReferences(semanticModel.Compilation.References, context.Logger);

--- a/src/MongoDB.Analyzer/Core/Builders/BuilderExpressionProcessor.cs
+++ b/src/MongoDB.Analyzer/Core/Builders/BuilderExpressionProcessor.cs
@@ -54,7 +54,7 @@ internal static class BuilderExpressionProcessor
         public static RewriteResult Invalid = new(RewriteAction.Invalid, null, null);
     }
 
-    public static ExpressionsAnalysis ProcessSemanticModel(MongoAnalyzerContext context)
+    public static ExpressionsAnalysis ProcessSemanticModel(MongoAnalysisContext context)
     {
         var semanticModel = context.SemanticModelAnalysisContext.SemanticModel;
         var syntaxTree = semanticModel.SyntaxTree;
@@ -63,7 +63,7 @@ internal static class BuilderExpressionProcessor
         var analysisContexts = new List<ExpressionAnalysisContext>();
         var invalidExpressionNodes = new List<InvalidExpressionAnalysisNode>();
 
-        var typesProcessor = new TypesProcessor();
+        var typesProcessor = context.TypesProcessor;
         var nodesProcessed = new HashSet<SyntaxNode>();
         var buildersToAnalysisContextMap = context.Settings.EnableVariableTracking ? new Dictionary<SyntaxNode, ExpressionAnalysisContext>() : null;
 

--- a/src/MongoDB.Analyzer/Core/Builders/BuildersAnalyzer.cs
+++ b/src/MongoDB.Analyzer/Core/Builders/BuildersAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MongoDB.Analyzer.Core.Builders;
 
 internal static class BuildersAnalyzer
 {
-    public static bool AnalyzeBuilders(MongoAnalyzerContext context)
+    public static bool AnalyzeBuilders(MongoAnalysisContext context)
     {
         var sw = Stopwatch.StartNew();
         var stats = AnalysisStats.Empty;
@@ -50,7 +50,7 @@ internal static class BuildersAnalyzer
         return telemetry.ExpressionsFound > 0;
     }
 
-    private static AnalysisStats ReportMqlOrInvalidExpressions(MongoAnalyzerContext context, ExpressionsAnalysis buildersAnalysis)
+    private static AnalysisStats ReportMqlOrInvalidExpressions(MongoAnalysisContext context, ExpressionsAnalysis buildersAnalysis)
     {
         var semanticContext = context.SemanticModelAnalysisContext;
         if (buildersAnalysis.AnalysisNodeContexts.EmptyOrNull())

--- a/src/MongoDB.Analyzer/Core/Linq/AnalysisCodeGenerator.cs
+++ b/src/MongoDB.Analyzer/Core/Linq/AnalysisCodeGenerator.cs
@@ -38,7 +38,7 @@ internal static class AnalysisCodeGenerator
         s_parseOptions = mqlGeneratorSyntaxTree.Options;
     }
 
-    public static CompilationResult Compile(MongoAnalyzerContext context, ExpressionsAnalysis linqExpressionAnalysis)
+    public static CompilationResult Compile(MongoAnalysisContext context, ExpressionsAnalysis linqExpressionAnalysis)
     {
         var semanticModel = context.SemanticModelAnalysisContext.SemanticModel;
         var referencesContainer = ReferencesProvider.GetReferences(semanticModel.Compilation.References, context.Logger);

--- a/src/MongoDB.Analyzer/Core/Linq/LinqAnalyzer.cs
+++ b/src/MongoDB.Analyzer/Core/Linq/LinqAnalyzer.cs
@@ -18,7 +18,7 @@ namespace MongoDB.Analyzer.Core.Linq;
 
 internal static class LinqAnalyzer
 {
-    public static bool AnalyzeIMongoQueryable(MongoAnalyzerContext context)
+    public static bool AnalyzeIMongoQueryable(MongoAnalysisContext context)
     {
         var sw = Stopwatch.StartNew();
         var stats = AnalysisStats.Empty;
@@ -51,7 +51,7 @@ internal static class LinqAnalyzer
         return telemetry.ExpressionsFound > 0;
     }
 
-    private static void ReportInvalidExpressions(MongoAnalyzerContext context, ExpressionsAnalysis linqExpressionAnalysis)
+    private static void ReportInvalidExpressions(MongoAnalysisContext context, ExpressionsAnalysis linqExpressionAnalysis)
     {
         var semanticContext = context.SemanticModelAnalysisContext;
 
@@ -74,7 +74,7 @@ internal static class LinqAnalyzer
         }
     }
 
-    private static AnalysisStats ReportMqlOrInvalidExpressions(MongoAnalyzerContext context, ExpressionsAnalysis linqExpressionAnalysis)
+    private static AnalysisStats ReportMqlOrInvalidExpressions(MongoAnalysisContext context, ExpressionsAnalysis linqExpressionAnalysis)
     {
         var semanticContext = context.SemanticModelAnalysisContext;
 

--- a/src/MongoDB.Analyzer/Core/Linq/LinqExpressionProcessor.cs
+++ b/src/MongoDB.Analyzer/Core/Linq/LinqExpressionProcessor.cs
@@ -45,7 +45,7 @@ internal static class LinqExpressionProcessor
         public static RewriteResult Invalid = new(RewriteAction.Invalid, null, null);
     }
 
-    public static ExpressionsAnalysis ProcessSemanticModel(MongoAnalyzerContext context)
+    public static ExpressionsAnalysis ProcessSemanticModel(MongoAnalysisContext context)
     {
         var semanticModel = context.SemanticModelAnalysisContext.SemanticModel;
         var syntaxTree = semanticModel.SyntaxTree;
@@ -55,7 +55,7 @@ internal static class LinqExpressionProcessor
         var analysisContexts = new List<ExpressionAnalysisContext>();
         var invalidExpressionNodes = new List<InvalidExpressionAnalysisNode>();
 
-        var typesProcessor = new TypesProcessor();
+        var typesProcessor = context.TypesProcessor;
 
         foreach (var node in root.DescendantNodesWithSkipList(processedSyntaxNodes).OfType<ExpressionSyntax>())
         {

--- a/src/MongoDB.Analyzer/Core/MongoAnalysisContext.cs
+++ b/src/MongoDB.Analyzer/Core/MongoAnalysisContext.cs
@@ -14,9 +14,10 @@
 
 namespace MongoDB.Analyzer.Core;
 
-internal record MongoAnalyzerContext(
+internal record MongoAnalysisContext(
     SemanticModelAnalysisContext SemanticModelAnalysisContext,
     MongoDBAnalyzerSettings Settings,
+    TypesProcessor TypesProcessor,
     Logger Logger,
     ITelemetryService Telemetry)
 {

--- a/src/MongoDB.Analyzer/MongoDBDiagnosticAnalyzer.cs
+++ b/src/MongoDB.Analyzer/MongoDBDiagnosticAnalyzer.cs
@@ -41,7 +41,8 @@ public sealed class MongoDBDiagnosticAnalyzer : DiagnosticAnalyzer
         using var telemetryService = SettingsHelper.CreateTelemetryService(settings, correlationId);
         using var logger = SettingsHelper.CreateLogger(settings, correlationId);
 
-        var mongoAnalyzerContext = new MongoAnalyzerContext(context, settings, logger, telemetryService);
+        var typesProcessor = new TypesProcessor();
+        var mongoAnalyzerContext = new MongoAnalysisContext(context, settings, typesProcessor, logger, telemetryService);
         var flushTelemetry = false;
 
         try


### PR DESCRIPTION
VS-95: Made TypesProcessor a shared instance between all Linq and Builders Operations